### PR TITLE
fix: GMAIL_LABEL defaults to INBOX when not configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,9 @@ DEBUG=false
 # === Gmail (IMAP + SMTP) ===
 GMAIL_ADDRESS=you@gmail.com
 GMAIL_APP_PASSWORD=xxxx xxxx xxxx xxxx
-GMAIL_LABEL=Newsletters
+# Leave empty or remove to read ALL emails from INBOX
+# Set to a Gmail label name (e.g. Newsletters) to only read that label
+GMAIL_LABEL=
 LOOKBACK_HOURS=24
 
 # === LLM Provider ===

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -38,7 +38,7 @@ jobs:
           DEBUG: ${{ github.event.inputs.debug || 'false' }}
           GMAIL_ADDRESS: ${{ secrets.GMAIL_ADDRESS }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
-          GMAIL_LABEL: ${{ secrets.GMAIL_LABEL || 'Newsletters' }}
+          GMAIL_LABEL: ${{ secrets.GMAIL_LABEL || '' }}
           LLM_PROVIDER: ${{ secrets.LLM_PROVIDER || 'qwen' }}
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
           QWEN_MODEL: ${{ secrets.QWEN_MODEL || 'qwen-plus' }}

--- a/src/config.py
+++ b/src/config.py
@@ -52,7 +52,7 @@ class Settings(BaseSettings):
     # Gmail
     gmail_address: str = ""
     gmail_app_password: str = ""
-    gmail_label: str = "Newsletters"
+    gmail_label: str = ""  # Empty = INBOX (all emails); set to a label name to filter
     lookback_hours: int = 24
 
     # LLM

--- a/src/sources/gmail.py
+++ b/src/sources/gmail.py
@@ -25,13 +25,14 @@ class GmailSource:
         self,
         address: str,
         app_password: str,
-        label: str = "Newsletters",
+        label: str = "",
         lookback_hours: int = 24,
         debug: bool = False,
     ):
         self.address = address
         self.app_password = app_password
-        self.label = label
+        # Empty string or not set → use INBOX (all emails)
+        self.label = label if label else "INBOX"
         self.lookback_hours = lookback_hours
         self.debug = debug
 


### PR DESCRIPTION
- Empty GMAIL_LABEL (or not set) now reads all emails from INBOX
- Only filters by label if explicitly configured (e.g. GMAIL_LABEL=Newsletters)
- Updated .env.example with clear documentation