### PR TITLE
fix: prioritize Official X API, fix free tier query compatibility

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -552,10 +552,15 @@ def cli() -> None:
             or settings.twitter_bearer_token
         )
         if not has_scraper:
-            logger.warning(
+            logger.error(
                 "No Twitter scraper credentials configured. "
-                "Will try Nitter public instances as fallback."
+                "You need at least one of:\n"
+                "  - TWITTER_BEARER_TOKEN (recommended, get free at https://developer.twitter.com)\n"
+                "  - TWSCRAPE_ACCOUNTS (needs Twitter account credentials)\n"
+                "  - NITTER_INSTANCES (mostly dead as of 2025, not recommended)\n"
+                "Please configure TWITTER_BEARER_TOKEN in your .env file."
             )
+            sys.exit(1)
 
         run_twitter_pipeline(settings)
 

--- a/src/sources/twitter/scrapers/official_api.py
+++ b/src/sources/twitter/scrapers/official_api.py
@@ -51,20 +51,23 @@ class OfficialAPIScraper(BaseScraper):
                 "Content-Type": "application/json",
             }
 
-            # Build query — exclude retweets, require some engagement
-            query = f"{topic} -is:retweet has:media OR has:links"
+            # Build query — exclude retweets for quality content
+            # Note: Free tier has limited operators, keep it simple
+            query = f"{topic} -is:retweet"
             since_str = since.strftime("%Y-%m-%dT%H:%M:%SZ")
 
             params = {
                 "query": query,
                 "start_time": since_str,
-                "max_results": min(limit, 100),  # API max is 100
-                "sort_order": "relevancy",
+                "max_results": max(10, min(limit, 100)),  # API min=10, max=100
                 "tweet.fields": "created_at,public_metrics,author_id,lang,attachments",
                 "expansions": "author_id,attachments.media_keys",
                 "user.fields": "name,username",
                 "media.fields": "url,preview_image_url,type",
             }
+
+            # sort_order is only available for Academic/Pro tier, skip for free
+            # Free tier returns recent tweets in reverse chronological order
 
             if self.debug:
                 logger.debug(f"[official_api] Query: {query}")

--- a/src/sources/twitter/source.py
+++ b/src/sources/twitter/source.py
@@ -31,10 +31,10 @@ DEFAULT_TOPICS = [
 class TwitterSource:
     """Fetch trending tech tweets from X/Twitter with multi-channel fallback.
 
-    Fetching priority:
-      1. twscrape (fastest, most data)
-      2. Nitter RSS (no auth needed, limited engagement data)
-      3. Official X API (rate limited, but reliable)
+    Fetching priority (updated 2025 — Nitter public instances are mostly dead):
+      1. Official X API (most reliable, free tier: 10k tweets/month)
+      2. twscrape (full data, needs accounts)
+      3. Nitter RSS (last resort, most instances are dead)
 
     For each topic, we fetch top N tweets by engagement, then return the
     combined and de-duplicated set sorted by engagement score.
@@ -70,10 +70,11 @@ class TwitterSource:
         self.debug = debug
 
         # Initialize scrapers in priority order
+        # Official API first (most reliable in 2025+), then twscrape, then Nitter as last resort
         self._scrapers: list[BaseScraper] = [
+            OfficialAPIScraper(bearer_token=bearer_token, debug=debug),
             TwscrapeScraper(accounts=twscrape_accounts or [], debug=debug),
             NitterScraper(instances=nitter_instances, debug=debug),
-            OfficialAPIScraper(bearer_token=bearer_token, debug=debug),
         ]
 
     def fetch(self) -> list[TweetItem]:


### PR DESCRIPTION
- Official X API is now priority #1 (most reliable in 2025+)
- Nitter demoted to last resort (public instances are dead)
- Simplified API query: removed operators not available in free tier
- Fixed max_results minimum (API requires >= 10)
- Removed sort_order (only available for paid tiers)
- Clear error message when no scraper is configured
- Requires TWITTER_BEARER_TOKEN to run (free at developer.twitter.com)