### PR TITLE
feat: add twikit as primary scraper (free, cookie-based, no API key)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,16 @@ TWITTER_TOP_PER_TOPIC=20
 # Final number of curated tweets in the briefing (Agent picks the best)
 TWITTER_FINAL_TOP=10
 
-# === Scraper Channel 1: twscrape (recommended, highest priority) ===
+# === Scraper Channel 1: twikit (RECOMMENDED, free, cookie-based) ===
+# Your X/Twitter account credentials (for first-time login)
+# After first login, cookies are saved and credentials aren't needed again.
+TWIKIT_USERNAME=your_x_username
+TWIKIT_EMAIL=your_email@example.com
+TWIKIT_PASSWORD=your_password
+# Optional: custom path for cookies file (default: .twikit_cookies.json)
+TWIKIT_COOKIES_PATH=
+
+# === Scraper Channel 2: twscrape (alternative, needs account pool) ===
 # Format: username:password:email:email_password (comma-separated for multiple accounts)
 # Get accounts at: https://github.com/vladkens/twscrape
 TWSCRAPE_ACCOUNTS=

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ demo_output.html
 
 # H5 output pages (auto-generated)
 output/
+
+
+# Twikit cookies (contains auth tokens, DO NOT commit)
+.twikit_cookies.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pydantic-settings>=2.3",
     "python-dotenv>=1.0",
     "httpx>=0.27",
-    "twscrape>=0.12",
+    "twikit>=2.0",
 ]
 
 [project.urls]

--- a/src/config.py
+++ b/src/config.py
@@ -86,6 +86,12 @@ class Settings(BaseSettings):
     twitter_top_per_topic: int = 20
     twitter_final_top: int = 10
 
+    # twikit (recommended, free, cookie-based)
+    twikit_username: str = ""
+    twikit_email: str = ""
+    twikit_password: str = ""
+    twikit_cookies_path: str = ""  # Path to cookies file, default: .twikit_cookies.json
+
     # twscrape accounts: "user1:pass1:email1:emailpass1,user2:pass2:email2:emailpass2"
     twscrape_accounts: str = ""
 

--- a/src/main.py
+++ b/src/main.py
@@ -140,6 +140,10 @@ def run_twitter_pipeline(settings: Settings) -> None:
         lookback_hours=settings.twitter_lookback_hours,
         top_per_topic=settings.twitter_top_per_topic,
         final_top=settings.twitter_final_top,
+        twikit_username=settings.twikit_username,
+        twikit_email=settings.twikit_email,
+        twikit_password=settings.twikit_password,
+        twikit_cookies_path=settings.twikit_cookies_path,
         twscrape_accounts=settings.get_twscrape_accounts(),
         nitter_instances=settings.get_nitter_instances(),
         bearer_token=settings.twitter_bearer_token,
@@ -547,7 +551,9 @@ def cli() -> None:
 
         # Check if at least one twitter scraper is configured
         has_scraper = (
-            settings.twscrape_accounts
+            settings.twikit_username
+            or settings.twikit_cookies_path
+            or settings.twscrape_accounts
             or settings.nitter_instances
             or settings.twitter_bearer_token
         )
@@ -555,10 +561,11 @@ def cli() -> None:
             logger.error(
                 "No Twitter scraper credentials configured. "
                 "You need at least one of:\n"
-                "  - TWITTER_BEARER_TOKEN (recommended, get free at https://developer.twitter.com)\n"
+                "  - TWIKIT_USERNAME + TWIKIT_PASSWORD + TWIKIT_EMAIL (recommended, free)\n"
+                "  - A cookies file at .twikit_cookies.json (from previous login)\n"
+                "  - TWITTER_BEARER_TOKEN (paid per-use since 2026)\n"
                 "  - TWSCRAPE_ACCOUNTS (needs Twitter account credentials)\n"
-                "  - NITTER_INSTANCES (mostly dead as of 2025, not recommended)\n"
-                "Please configure TWITTER_BEARER_TOKEN in your .env file."
+                "Please configure twikit credentials in your .env file."
             )
             sys.exit(1)
 

--- a/src/sources/twitter/scrapers/__init__.py
+++ b/src/sources/twitter/scrapers/__init__.py
@@ -1,6 +1,7 @@
 """Twitter scrapers — multi-channel fetching with fallback."""
 
 from src.sources.twitter.scrapers.base import BaseScraper, ScraperError
+from src.sources.twitter.scrapers.twikit_scraper import TwikitScraper
 from src.sources.twitter.scrapers.twscrape_scraper import TwscrapeScraper
 from src.sources.twitter.scrapers.nitter_scraper import NitterScraper
 from src.sources.twitter.scrapers.official_api import OfficialAPIScraper
@@ -8,6 +9,7 @@ from src.sources.twitter.scrapers.official_api import OfficialAPIScraper
 __all__ = [
     "BaseScraper",
     "ScraperError",
+    "TwikitScraper",
     "TwscrapeScraper",
     "NitterScraper",
     "OfficialAPIScraper",

--- a/src/sources/twitter/scrapers/twikit_scraper.py
+++ b/src/sources/twitter/scrapers/twikit_scraper.py
@@ -1,0 +1,252 @@
+"""Scraper channel: twikit — cookie-based Twitter scraper (no API key needed).
+
+twikit uses Twitter's internal GraphQL API with cookie authentication.
+It's free, actively maintained (2026), and provides full tweet data including
+engagement metrics.
+
+Requires: pip install twikit
+Config: TWIKIT_USERNAME, TWIKIT_EMAIL, TWIKIT_PASSWORD, or a cookies file.
+
+Usage:
+    First run: logs in with credentials, saves cookies to disk.
+    Subsequent runs: loads cookies from disk (no login needed).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.sources.twitter.models import TweetItem
+from src.sources.twitter.scrapers.base import BaseScraper, ScraperError
+
+logger = logging.getLogger(__name__)
+
+# Default cookies file path
+DEFAULT_COOKIES_PATH = Path(".twikit_cookies.json")
+
+
+class TwikitScraper(BaseScraper):
+    """Fetch tweets using twikit library (cookie-based, no API key)."""
+
+    name = "twikit"
+
+    def __init__(
+        self,
+        username: str = "",
+        email: str = "",
+        password: str = "",
+        cookies_path: str = "",
+        debug: bool = False,
+    ):
+        """Initialize twikit scraper.
+
+        Args:
+            username: X/Twitter username (for first-time login).
+            email: Email associated with the X account.
+            password: Account password.
+            cookies_path: Path to save/load cookies file.
+            debug: Enable debug logging.
+        """
+        self.username = username
+        self.email = email
+        self.password = password
+        self.cookies_path = Path(cookies_path) if cookies_path else DEFAULT_COOKIES_PATH
+        self.debug = debug
+        self._client = None
+
+    async def _get_client(self):
+        """Lazy-initialize and authenticate the twikit client."""
+        if self._client is not None:
+            return self._client
+
+        try:
+            from twikit import Client
+        except ImportError:
+            raise ScraperError(
+                "twikit is not installed. Run: pip install twikit"
+            )
+
+        try:
+            client = Client("en-US")
+
+            # Try loading existing cookies first
+            if self.cookies_path.exists():
+                if self.debug:
+                    logger.debug(f"[twikit] Loading cookies from {self.cookies_path}")
+                client.load_cookies(str(self.cookies_path))
+                self._client = client
+                return self._client
+
+            # No cookies — need to login with credentials
+            if not self.username or not self.password:
+                raise ScraperError(
+                    "twikit requires either a cookies file or credentials "
+                    "(TWIKIT_USERNAME + TWIKIT_PASSWORD + TWIKIT_EMAIL). "
+                    "Please configure them in your .env file."
+                )
+
+            if self.debug:
+                logger.debug(f"[twikit] Logging in as {self.username}...")
+
+            await client.login(
+                auth_info_1=self.username,
+                auth_info_2=self.email,
+                password=self.password,
+            )
+
+            # Save cookies for future use
+            client.save_cookies(str(self.cookies_path))
+            if self.debug:
+                logger.debug(f"[twikit] Cookies saved to {self.cookies_path}")
+
+            self._client = client
+            return self._client
+
+        except ScraperError:
+            raise
+        except Exception as e:
+            raise ScraperError(f"Failed to initialize twikit client: {e}")
+
+    async def fetch_by_topic(
+        self,
+        topic: str,
+        since: datetime,
+        limit: int = 20,
+    ) -> list[TweetItem]:
+        """Fetch tweets for a topic using twikit search."""
+        try:
+            client = await self._get_client()
+
+            # twikit search_tweet: query, product ('Top', 'Latest', 'People', 'Media')
+            # 'Top' gives us popular/engaging tweets
+            if self.debug:
+                logger.debug(f"[twikit] Searching: '{topic}' (product=Top, limit={limit})")
+
+            result = await client.search_tweet(topic, product="Top", count=limit)
+
+            tweets: list[TweetItem] = []
+
+            for tweet in result:
+                try:
+                    parsed = self._parse_tweet(tweet, topic, since)
+                    if parsed:
+                        tweets.append(parsed)
+                except Exception as e:
+                    if self.debug:
+                        logger.debug(f"[twikit] Failed to parse tweet: {e}")
+                    continue
+
+            # Sort by engagement score
+            tweets.sort(key=lambda t: t.engagement_score, reverse=True)
+
+            if self.debug:
+                logger.debug(
+                    f"[twikit] Topic '{topic}': found {len(tweets)} tweets"
+                )
+
+            return tweets[:limit]
+
+        except ScraperError:
+            raise
+        except Exception as e:
+            # If cookies expired, try to re-login
+            if "401" in str(e) or "403" in str(e) or "unauthorized" in str(e).lower():
+                logger.warning(f"[twikit] Auth error, cookies may be expired: {e}")
+                # Delete stale cookies and retry login next time
+                if self.cookies_path.exists():
+                    self.cookies_path.unlink()
+                    self._client = None
+                raise ScraperError(
+                    f"twikit auth expired for topic '{topic}'. "
+                    f"Cookies deleted, will re-login next run. Error: {e}"
+                )
+            raise ScraperError(f"twikit fetch failed for topic '{topic}': {e}")
+
+    def _parse_tweet(
+        self,
+        tweet,
+        topic: str,
+        since: datetime,
+    ) -> TweetItem | None:
+        """Parse a twikit Tweet object into our TweetItem model."""
+        try:
+            # Get tweet creation date
+            created_at = tweet.created_at
+            if isinstance(created_at, str):
+                # twikit returns date as string like "Thu May 15 01:00:00 +0000 2026"
+                from email.utils import parsedate_to_datetime
+                try:
+                    tweet_date = parsedate_to_datetime(created_at)
+                except (ValueError, TypeError):
+                    tweet_date = datetime.now(timezone.utc)
+            elif isinstance(created_at, datetime):
+                tweet_date = created_at
+            else:
+                tweet_date = datetime.now(timezone.utc)
+
+            if tweet_date.tzinfo is None:
+                tweet_date = tweet_date.replace(tzinfo=timezone.utc)
+
+            # Filter by time window
+            if tweet_date < since:
+                return None
+
+            # Extract user info
+            user = tweet.user
+            author_name = user.name if user else "Unknown"
+            author_handle = user.screen_name if user else ""
+
+            # Extract media URLs
+            media_urls = []
+            if hasattr(tweet, "media") and tweet.media:
+                for media in tweet.media:
+                    if hasattr(media, "media_url_https"):
+                        media_urls.append(media.media_url_https)
+                    elif hasattr(media, "url"):
+                        media_urls.append(media.url)
+
+            # Build tweet URL
+            tweet_id = str(tweet.id)
+            link = f"https://x.com/{author_handle}/status/{tweet_id}" if author_handle else ""
+
+            # Get engagement metrics
+            likes = getattr(tweet, "favorite_count", 0) or 0
+            retweets = getattr(tweet, "retweet_count", 0) or 0
+            replies = getattr(tweet, "reply_count", 0) or 0
+            views = getattr(tweet, "view_count", 0) or 0
+
+            # Get full text
+            text = getattr(tweet, "full_text", "") or getattr(tweet, "text", "") or ""
+
+            return TweetItem(
+                id=tweet_id,
+                author=author_name,
+                author_handle=author_handle,
+                content=text,
+                date=tweet_date,
+                likes=likes,
+                retweets=retweets,
+                replies=replies,
+                views=views,
+                media_urls=media_urls,
+                link=link,
+                topic=topic,
+                language=getattr(tweet, "lang", "") or "",
+            )
+        except Exception as e:
+            if self.debug:
+                logger.debug(f"[twikit] Parse error: {e}")
+            return None
+
+    async def is_available(self) -> bool:
+        """Check if twikit is installed and credentials/cookies are available."""
+        try:
+            import twikit  # noqa: F401
+            # Available if we have cookies OR credentials
+            has_cookies = self.cookies_path.exists()
+            has_credentials = bool(self.username and self.password)
+            return has_cookies or has_credentials
+        except ImportError:
+            return False

--- a/src/sources/twitter/source.py
+++ b/src/sources/twitter/source.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 
 from src.sources.twitter.models import TweetItem
 from src.sources.twitter.scrapers.base import BaseScraper, ScraperError
+from src.sources.twitter.scrapers.twikit_scraper import TwikitScraper
 from src.sources.twitter.scrapers.twscrape_scraper import TwscrapeScraper
 from src.sources.twitter.scrapers.nitter_scraper import NitterScraper
 from src.sources.twitter.scrapers.official_api import OfficialAPIScraper
@@ -46,6 +47,10 @@ class TwitterSource:
         lookback_hours: int = 24,
         top_per_topic: int = 20,
         final_top: int = 10,
+        twikit_username: str = "",
+        twikit_email: str = "",
+        twikit_password: str = "",
+        twikit_cookies_path: str = "",
         twscrape_accounts: list[dict] | None = None,
         nitter_instances: list[str] | None = None,
         bearer_token: str = "",
@@ -58,6 +63,10 @@ class TwitterSource:
             lookback_hours: How far back to look for tweets.
             top_per_topic: How many top tweets to fetch per topic.
             final_top: How many tweets to include in final output (for Agent).
+            twikit_username: X username for twikit login.
+            twikit_email: Email for twikit login.
+            twikit_password: Password for twikit login.
+            twikit_cookies_path: Path to twikit cookies file.
             twscrape_accounts: Account dicts for twscrape.
             nitter_instances: Nitter instance URLs.
             bearer_token: X API Bearer Token.
@@ -69,9 +78,19 @@ class TwitterSource:
         self.final_top = final_top
         self.debug = debug
 
-        # Initialize scrapers in priority order
-        # Official API first (most reliable in 2025+), then twscrape, then Nitter as last resort
+        # Initialize scrapers in priority order:
+        # 1. twikit (free, cookie-based, best data)
+        # 2. Official API (paid per-use since 2026)
+        # 3. twscrape (needs account pool)
+        # 4. Nitter (last resort, mostly dead)
         self._scrapers: list[BaseScraper] = [
+            TwikitScraper(
+                username=twikit_username,
+                email=twikit_email,
+                password=twikit_password,
+                cookies_path=twikit_cookies_path,
+                debug=debug,
+            ),
             OfficialAPIScraper(bearer_token=bearer_token, debug=debug),
             TwscrapeScraper(accounts=twscrape_accounts or [], debug=debug),
             NitterScraper(instances=nitter_instances, debug=debug),


### PR DESCRIPTION
- New TwikitScraper: uses twikit library with cookie authentication
- twikit is now priority #1 (free, full data, actively maintained)
- First login saves cookies; subsequent runs use cookies (no re-login)
- Auto-handles cookie expiration (deletes stale, re-logins next run)
- Config: TWIKIT_USERNAME, TWIKIT_EMAIL, TWIKIT_PASSWORD
- Fallback chain: twikit → Official API → twscrape → Nitter
- Updated pyproject.toml: twikit>=2.0 replaces twscrape as primary dep
- Cookies file (.twikit_cookies.json) gitignored for security